### PR TITLE
chore: release v0.1.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "found-it-hello-rs"
-version = "0.1.25"
+version = "0.1.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "found-it-hello-rs"
 license = "Apache-2.0"
 description = "First crate to publish"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION



## 🤖 New release

* `found-it-hello-rs`: 0.1.25 -> 0.1.26 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).